### PR TITLE
Adjust how values are scaled (adds multiplier & warning)

### DIFF
--- a/R/compare-values.R
+++ b/R/compare-values.R
@@ -13,8 +13,8 @@
 #' @param round_all logical value to indicate if all values should be rounded.
 #' When FALSE, the values will return with no modification. When TRUE (default)
 #' all values will be round to the length specified by 'n_decimal'.
-#' @param rescale number indicating the scaling factor. When rescale = 1
-#' (default), 0.25 will return 0.25. When rescale = 100, 0.25 will return 25.
+#' @param multiplier number indicating the scaling factor. When multiplier = 1
+#' (default), 0.25 will return 0.25. When multiplier = 100, 0.25 will return 25.
 #' @importFrom glue glue
 #' @importFrom purrr map_if map pluck
 #' @importFrom dplyr recode
@@ -37,16 +37,21 @@
 #' # you can also adjust the rounding, although the default is 1
 #' compare_values(0.1234, 0.4321)$orig_values
 #' compare_values(0.1234, 0.4321, n_decimal = 3)$orig_values
+#' # or add a multiplier
+#' compare_values(0.1234, 0.4321, multiplier = 100)$orig_values
 compare_values <- function(compare, reference,
                            trend_phrasing = headliner::trend_terms(),
                            orig_values = "{c} vs. {r}",
                            plural_phrases = NULL,
                            n_decimal = 1,
                            round_all = TRUE,
-                           rescale = 1) {
+                           multiplier = 1) {
   # calcs
-  calc <- as.numeric((compare * rescale) - (reference * rescale))
-  calc_p <- as.numeric((compare - reference) / reference  * 100)
+  comp <- (compare * multiplier)
+  ref <- (reference * multiplier)
+
+  calc <- as.numeric(comp - ref)
+  calc_p <- as.numeric(calc / ref  * 100)
 
   sign_calc <- sign(calc)
 
@@ -74,12 +79,20 @@ compare_values <- function(compare, reference,
       sign = sign_calc,
       orig_values = glue(
         orig_values,
-        c = round(compare, n_decimal),
-        r = round(reference, n_decimal)
+        c = round(comp, n_decimal),
+        r = round(ref, n_decimal)
       )
     )
 
   if (round_all) {
+    # give a warning if rounding causes a delta of 0 due to inputs having
+    # decimals >= n_decimal parameter
+    check_rounding(
+      x = output$comp_value,
+      y = output$ref_value,
+      n_decimal = n_decimal
+    )
+
     output <-
       output %>%
       map_if(is.numeric, round, n_decimal)

--- a/R/compare-values.R
+++ b/R/compare-values.R
@@ -13,8 +13,8 @@
 #' @param round_all logical value to indicate if all values should be rounded.
 #' When FALSE, the values will return with no modification. When TRUE (default)
 #' all values will be round to the length specified by 'n_decimal'.
-#' @param scale number indicating the scaling factor. When scale = 1, 1/4 will
-#' return 0.25, when scale = 100 (default) 1/4 will return 25
+#' @param rescale number indicating the scaling factor. When rescale = 1
+#' (default), 0.25 will return 0.25. When rescale = 100, 0.25 will return 25.
 #' @importFrom glue glue
 #' @importFrom purrr map_if map pluck
 #' @importFrom dplyr recode
@@ -43,10 +43,10 @@ compare_values <- function(compare, reference,
                            plural_phrases = NULL,
                            n_decimal = 1,
                            round_all = TRUE,
-                           scale = 100) {
+                           rescale = 1) {
   # calcs
-  calc <- as.numeric(compare - reference)
-  calc_p <- as.numeric((compare - reference) / reference  * scale)
+  calc <- as.numeric((compare * rescale) - (reference * rescale))
+  calc_p <- as.numeric((compare - reference) / reference  * 100)
 
   sign_calc <- sign(calc)
 

--- a/R/headline.R
+++ b/R/headline.R
@@ -23,8 +23,8 @@ headline <- function(...) {
 #' @param round_all logical value to indicate if all values should be rounded.
 #' When FALSE, the values will return with no modification. When TRUE (default)
 #' all values will be round to the length specified by 'n_decimal'.
-#' @param scale number indicating the scaling factor. When scale = 1, 1/4 will
-#' return 0.25, when scale = 100 (default) 1/4 will return 25
+#' @param multiplier number indicating the scaling factor. When multiplier = 1
+#' (default), 0.25 will return 0.25. When multiplier = 100, 0.25 will return 25.
 #' @param return_data logical to indicate whether function should return the
 #' phrase components used to compose the headline
 #' @importFrom glue glue_data
@@ -71,6 +71,8 @@ headline <- function(...) {
 #' # you can also adjust the rounding, although the default is 1
 #' headline(0.1234, 0.4321)
 #' headline(0.1234, 0.4321, n_decimal = 3)
+#' # or use a multiplier
+#' headline(0.1234, 0.4321, multiplier = 100)
 #'
 #' # The values can come from a summarized data frame or a named list
 #' # if the data frame is only 2 columns or the list has only 2 elements
@@ -119,7 +121,7 @@ headline.default <- function(compare,
                              orig_values = "{c} vs. {r}",
                              n_decimal = 1,
                              round_all = TRUE,
-                             scale = 100,
+                             multiplier = 1,
                              return_data = FALSE) {
   res <-
     compare_values(
@@ -130,7 +132,7 @@ headline.default <- function(compare,
       orig_values = orig_values,
       n_decimal = n_decimal,
       round_all = round_all,
-      scale = scale
+      multiplier = multiplier
     )
 
 

--- a/R/utils-data-manipulation.R
+++ b/R/utils-data-manipulation.R
@@ -86,3 +86,46 @@ get_article <- function(x) {
     )
   }
 }
+
+
+
+#' Checks to see if rounding is causing the zero
+#' @param x compare value from compare_values()
+#' @param y reference value from compare_values()
+#' @param n_decimal n_decimal value from compare_values()
+#' @importFrom glue glue
+#' @noRd
+#' @examples
+#' check_rounding(x = 0.2, y = 0.24, n_decimal = 1)
+#' check_rounding(x = 0.2, y = 0.24, n_decimal = 2)
+check_rounding <- function(x, y, n_decimal) {
+  # only need if delta comes back as zero
+  if (round(x - y, n_decimal) != 0) return()
+  # both values need to be less than 2...  if (abs(x) + abs(y) > 2) return()
+
+  n_decimals <- function(num) {
+    n <-
+      num %>%
+      as.numeric() %>%  # turn 1.200 into 1.2
+      as.character() %>%
+      stringr::str_extract("(?<=\\.).*[^0]$") %>%
+      nchar()
+    ifelse(is.na(n), 0, n)
+  }
+
+  max_decimals <- max(n_decimals(c(x, y)), na.rm = TRUE)[1]
+
+  if (n_decimal <= max_decimals & max_decimals != 0) {
+    warning(
+      glue(
+        "With the rounding applied ('n_decimal = {n_decimal}'), \\
+        your result shows a change of zero
+
+        Your inputs had a maximum decimal length of {max_decimals} ({x}, {y}).
+        Consider increasing the 'n_decimal' parameter to \\
+        {max_decimals + 1} or more"
+      ),
+      call. = FALSE
+    )
+  }
+}

--- a/R/utils-data-manipulation.R
+++ b/R/utils-data-manipulation.R
@@ -108,8 +108,10 @@ check_rounding <- function(x, y, n_decimal) {
       num %>%
       as.numeric() %>%  # turn 1.200 into 1.2
       as.character() %>%
-      stringr::str_extract("(?<=\\.).*[^0]$") %>%
+      # remove anything up to and including the period
+      gsub(pattern = "^[^\\.]*(\\.)?", replacement = "") %>%
       nchar()
+
     ifelse(is.na(n), 0, n)
   }
 

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -2,5 +2,5 @@ pandoc: 2.7.2
 pkgdown: 1.5.1
 pkgdown_sha: ~
 articles: []
-last_built: 2020-10-27T04:26Z
+last_built: 2020-10-30T03:31Z
 

--- a/docs/reference/compare_columns.html
+++ b/docs/reference/compare_columns.html
@@ -150,10 +150,10 @@ list(mean = ~mean(.x, na.rm = TRUE), sd = sd)</p></td>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='fu'>compare_columns</span>(<span class='no'>flights_jfk</span>, )</div><div class='output co'>#&gt; <span class='warning'>Warning: argument is not numeric or logical: returning NA</span></div><div class='output co'>#&gt; <span class='warning'>Warning: argument is not numeric or logical: returning NA</span></div><div class='output co'>#&gt; <span class='warning'>Warning: argument is not numeric or logical: returning NA</span></div><div class='output co'>#&gt; $mean_air_time
-#&gt; [1] 328
+#&gt; [1] 327.7805
 #&gt; 
 #&gt; $mean_arr_delay
-#&gt; [1] 0.146
+#&gt; [1] 0.1459121
 #&gt; 
 #&gt; $mean_carrier
 #&gt; [1] NA
@@ -162,51 +162,51 @@ list(mean = ~mean(.x, na.rm = TRUE), sd = sd)</p></td>
 #&gt; [1] "2013-01-01"
 #&gt; 
 #&gt; $mean_dep_delay
-#&gt; [1] 10.4
+#&gt; [1] 10.41128
 #&gt; 
 #&gt; $mean_dest
 #&gt; [1] NA
 #&gt; 
 #&gt; $mean_dewp
-#&gt; [1] 41.1
+#&gt; [1] 41.06711
 #&gt; 
 #&gt; $mean_distance
-#&gt; [1] 2454
+#&gt; [1] 2453.746
 #&gt; 
 #&gt; $mean_hour
-#&gt; [1] 15
+#&gt; [1] 15.03484
 #&gt; 
 #&gt; $mean_humid
-#&gt; [1] 57.2
+#&gt; [1] 57.20094
 #&gt; 
 #&gt; $mean_precip
-#&gt; [1] 0.00149
+#&gt; [1] 0.001494147
 #&gt; 
 #&gt; $mean_pressure
-#&gt; [1] 1018
+#&gt; [1] 1018.002
 #&gt; 
 #&gt; $mean_tailnum
 #&gt; [1] NA
 #&gt; 
 #&gt; $mean_temp
-#&gt; [1] 57.3
+#&gt; [1] 57.27722
 #&gt; 
 #&gt; $mean_visib
-#&gt; [1] 9.58
+#&gt; [1] 9.576753
 #&gt; 
 #&gt; $mean_wind_dir
-#&gt; [1] 208
+#&gt; [1] 207.5795
 #&gt; 
 #&gt; $mean_wind_speed
-#&gt; [1] 12.4
+#&gt; [1] 12.43572
 #&gt; 
 #&gt; $mean_year
-#&gt; [1] 2012
+#&gt; [1] 2012.5
 #&gt; </div><div class='input'><span class='fu'>compare_columns</span>(<span class='no'>flights_jfk</span>, <span class='fu'>ends_with</span>(<span class='st'>"delay"</span>))</div><div class='output co'>#&gt; $mean_arr_delay
-#&gt; [1] 0.146
+#&gt; [1] 0.1459121
 #&gt; 
 #&gt; $mean_dep_delay
-#&gt; [1] 10.4
+#&gt; [1] 10.41128
 #&gt; </div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/docs/reference/compare_conditions.html
+++ b/docs/reference/compare_conditions.html
@@ -170,15 +170,15 @@ list(mean = ~mean(.x, na.rm = TRUE), sd = sd)</p></td>
     <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='no'>dep_delay</span>, <span class='no'>arr_delay</span>),
     <span class='kw'>calc</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/list.html'>list</a></span>(<span class='kw'>mean</span> <span class='kw'>=</span> <span class='no'>mean</span>, <span class='kw'>sd</span> <span class='kw'>=</span> <span class='no'>sd</span>)
   ) <span class='kw'>%&gt;%</span>
-  <span class='fu'><a href='view_list.html'>view_list</a></span>()</div><div class='output co'>#&gt;                     VALUES
-#&gt; mean_arr_delay_comp  3.554
-#&gt; mean_arr_delay_ref   0.146
-#&gt; mean_dep_delay_comp 13.407
-#&gt; mean_dep_delay_ref  10.411
-#&gt; sd_arr_delay_comp   53.368
-#&gt; sd_arr_delay_ref    44.039
-#&gt; sd_dep_delay_comp   47.973
-#&gt; sd_dep_delay_ref    37.779</div><div class='input'>
+  <span class='fu'><a href='view_list.html'>view_list</a></span>()</div><div class='output co'>#&gt;                         VALUES
+#&gt; mean_arr_delay_comp  3.5536618
+#&gt; mean_arr_delay_ref   0.1459121
+#&gt; mean_dep_delay_comp 13.4071904
+#&gt; mean_dep_delay_ref  10.4112821
+#&gt; sd_arr_delay_comp   53.3677492
+#&gt; sd_arr_delay_ref    44.0386496
+#&gt; sd_dep_delay_comp   47.9725670
+#&gt; sd_dep_delay_ref    37.7792880</div><div class='input'>
 <span class='no'>mtcars</span> <span class='kw'>%&gt;%</span>
   <span class='fu'>compare_conditions</span>(
     <span class='kw'>compare</span> <span class='kw'>=</span> (<span class='no'>hp</span> <span class='kw'>&gt;</span> <span class='fl'>100</span> <span class='kw'>|</span> <span class='no'>gear</span> <span class='kw'>==</span> <span class='fl'>4</span>),
@@ -186,15 +186,15 @@ list(mean = ~mean(.x, na.rm = TRUE), sd = sd)</p></td>
     <span class='kw pkg'>dplyr</span><span class='kw ns'>::</span><span class='fu'><a href='https://dplyr.tidyverse.org/reference/reexports.html'>starts_with</a></span>(<span class='st'>"d"</span>),
     <span class='kw'>calc</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/list.html'>list</a></span>(<span class='kw'>mean</span> <span class='kw'>=</span> <span class='no'>mean</span>, <span class='kw'>max</span> <span class='kw'>=</span> <span class='no'>max</span>)
   ) <span class='kw'>%&gt;%</span>
-  <span class='fu'><a href='view_list.html'>view_list</a></span>()</div><div class='output co'>#&gt;                VALUES
-#&gt; max_disp_comp  472.00
-#&gt; max_disp_ref   146.70
-#&gt; max_drat_comp    4.93
-#&gt; max_drat_ref     4.93
-#&gt; mean_disp_comp 238.09
-#&gt; mean_disp_ref   95.23
-#&gt; mean_drat_comp   3.57
-#&gt; mean_drat_ref    4.17</div></pre>
+  <span class='fu'><a href='view_list.html'>view_list</a></span>()</div><div class='output co'>#&gt;                    VALUES
+#&gt; max_disp_comp  472.000000
+#&gt; max_disp_ref   146.700000
+#&gt; max_drat_comp    4.930000
+#&gt; max_drat_ref     4.930000
+#&gt; mean_disp_comp 238.090000
+#&gt; mean_disp_ref   95.228571
+#&gt; mean_drat_comp   3.565333
+#&gt; mean_drat_ref    4.171429</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
     <nav id="toc" data-toggle="toc" class="sticky-top">

--- a/docs/reference/compare_values.html
+++ b/docs/reference/compare_values.html
@@ -133,7 +133,7 @@
   <span class='kw'>plural_phrases</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>n_decimal</span> <span class='kw'>=</span> <span class='fl'>1</span>,
   <span class='kw'>round_all</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
-  <span class='kw'>scale</span> <span class='kw'>=</span> <span class='fl'>100</span>
+  <span class='kw'>multiplier</span> <span class='kw'>=</span> <span class='fl'>1</span>
 )</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
@@ -174,9 +174,9 @@ When FALSE, the values will return with no modification. When TRUE (default)
 all values will be round to the length specified by 'n_decimal'.</p></td>
     </tr>
     <tr>
-      <th>scale</th>
-      <td><p>number indicating the scaling factor. When scale = 1, 1/4 will
-return 0.25, when scale = 100 (default) 1/4 will return 25</p></td>
+      <th>multiplier</th>
+      <td><p>number indicating the scaling factor. When multiplier = 1
+(default), 0.25 will return 0.25. When multiplier = 100, 0.25 will return 25.</p></td>
     </tr>
     </table>
 
@@ -204,7 +204,8 @@ return 0.25, when scale = 100 (default) 1/4 will return 25</p></td>
 <span class='co'># 'c' = the 'compare' value, 'r' = 'reference'</span>
 <span class='fu'>compare_values</span>(<span class='fl'>10</span>, <span class='fl'>8</span>, <span class='kw'>orig_values</span> <span class='kw'>=</span> <span class='st'>"{c} to {r} people"</span>)$<span class='no'>orig_values</span></div><div class='output co'>#&gt; 10 to 8 people</div><div class='input'>
 <span class='co'># you can also adjust the rounding, although the default is 1</span>
-<span class='fu'>compare_values</span>(<span class='fl'>0.1234</span>, <span class='fl'>0.4321</span>)$<span class='no'>orig_values</span></div><div class='output co'>#&gt; 0.1 vs. 0.4</div><div class='input'><span class='fu'>compare_values</span>(<span class='fl'>0.1234</span>, <span class='fl'>0.4321</span>, <span class='kw'>n_decimal</span> <span class='kw'>=</span> <span class='fl'>3</span>)$<span class='no'>orig_values</span></div><div class='output co'>#&gt; 0.123 vs. 0.432</div></pre>
+<span class='fu'>compare_values</span>(<span class='fl'>0.1234</span>, <span class='fl'>0.4321</span>)$<span class='no'>orig_values</span></div><div class='output co'>#&gt; 0.1 vs. 0.4</div><div class='input'><span class='fu'>compare_values</span>(<span class='fl'>0.1234</span>, <span class='fl'>0.4321</span>, <span class='kw'>n_decimal</span> <span class='kw'>=</span> <span class='fl'>3</span>)$<span class='no'>orig_values</span></div><div class='output co'>#&gt; 0.123 vs. 0.432</div><div class='input'><span class='co'># or add a multiplier</span>
+<span class='fu'>compare_values</span>(<span class='fl'>0.1234</span>, <span class='fl'>0.4321</span>, <span class='kw'>multiplier</span> <span class='kw'>=</span> <span class='fl'>100</span>)$<span class='no'>orig_values</span></div><div class='output co'>#&gt; 12.3 vs. 43.2</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
     <nav id="toc" data-toggle="toc" class="sticky-top">

--- a/docs/reference/demo_data.html
+++ b/docs/reference/demo_data.html
@@ -143,33 +143,19 @@
 
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
-    <pre class="examples"><div class='input'><span class='fu'>demo_data</span>()</div><div class='output co'>#&gt; <span style='color: #949494;'># A tibble: 10 x 5</span><span>
+    <pre class="examples"><div class='input'><span class='fu'>demo_data</span>()</div><div class='output co'>#&gt; <span style='color: #555555;'># A tibble: 10 x 5</span><span>
 #&gt;    group     x     y     z date      
-<<<<<<< Updated upstream
 #&gt;    </span><span style='color: #555555;font-style: italic;'>&lt;chr&gt;</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;date&gt;</span><span>    
-#&gt; </span><span style='color: #555555;'> 1</span><span> a       101    10     1 2020-10-26
-#&gt; </span><span style='color: #555555;'> 2</span><span> a       102    20     0 2020-08-26
-#&gt; </span><span style='color: #555555;'> 3</span><span> b       103    30     1 2020-06-26
-#&gt; </span><span style='color: #555555;'> 4</span><span> b       104    40     0 2020-04-26
-#&gt; </span><span style='color: #555555;'> 5</span><span> c       105    50     1 2020-02-26
-#&gt; </span><span style='color: #555555;'> 6</span><span> c       106    60     0 2019-12-26
-#&gt; </span><span style='color: #555555;'> 7</span><span> d       107    70     1 2019-10-26
-#&gt; </span><span style='color: #555555;'> 8</span><span> d       108    80     0 2019-08-26
-#&gt; </span><span style='color: #555555;'> 9</span><span> e       109    90     1 2019-06-26
-#&gt; </span><span style='color: #555555;'>10</span><span> e       110   100     0 2019-04-26</div></span></pre>
-=======
-#&gt;    </span><span style='color: #949494;font-style: italic;'>&lt;chr&gt;</span><span> </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #949494;font-style: italic;'>&lt;date&gt;</span><span>    
-#&gt; </span><span style='color: #BCBCBC;'> 1</span><span> a       101    10     1 2020-10-26
-#&gt; </span><span style='color: #BCBCBC;'> 2</span><span> a       102    20     0 2020-08-27
-#&gt; </span><span style='color: #BCBCBC;'> 3</span><span> b       103    30     1 2020-06-28
-#&gt; </span><span style='color: #BCBCBC;'> 4</span><span> b       104    40     0 2020-04-29
-#&gt; </span><span style='color: #BCBCBC;'> 5</span><span> c       105    50     1 2020-02-29
-#&gt; </span><span style='color: #BCBCBC;'> 6</span><span> c       106    60     0 2019-12-31
-#&gt; </span><span style='color: #BCBCBC;'> 7</span><span> d       107    70     1 2019-11-01
-#&gt; </span><span style='color: #BCBCBC;'> 8</span><span> d       108    80     0 2019-09-02
-#&gt; </span><span style='color: #BCBCBC;'> 9</span><span> e       109    90     1 2019-07-04
-#&gt; </span><span style='color: #BCBCBC;'>10</span><span> e       110   100     0 2019-05-05</div></span></pre>
->>>>>>> Stashed changes
+#&gt; </span><span style='color: #555555;'> 1</span><span> a       101    10     1 2020-10-29
+#&gt; </span><span style='color: #555555;'> 2</span><span> a       102    20     0 2020-08-29
+#&gt; </span><span style='color: #555555;'> 3</span><span> b       103    30     1 2020-06-29
+#&gt; </span><span style='color: #555555;'> 4</span><span> b       104    40     0 2020-04-29
+#&gt; </span><span style='color: #555555;'> 5</span><span> c       105    50     1 2020-02-29
+#&gt; </span><span style='color: #555555;'> 6</span><span> c       106    60     0 2019-12-29
+#&gt; </span><span style='color: #555555;'> 7</span><span> d       107    70     1 2019-10-29
+#&gt; </span><span style='color: #555555;'> 8</span><span> d       108    80     0 2019-08-29
+#&gt; </span><span style='color: #555555;'> 9</span><span> e       109    90     1 2019-06-29
+#&gt; </span><span style='color: #555555;'>10</span><span> e       110   100     0 2019-04-29</div></span></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
     <nav id="toc" data-toggle="toc" class="sticky-top">

--- a/docs/reference/headline.html
+++ b/docs/reference/headline.html
@@ -139,7 +139,7 @@
   <span class='kw'>orig_values</span> <span class='kw'>=</span> <span class='st'>"{c} vs. {r}"</span>,
   <span class='kw'>n_decimal</span> <span class='kw'>=</span> <span class='fl'>1</span>,
   <span class='kw'>round_all</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
-  <span class='kw'>scale</span> <span class='kw'>=</span> <span class='fl'>100</span>,
+  <span class='kw'>multiplier</span> <span class='kw'>=</span> <span class='fl'>1</span>,
   <span class='kw'>return_data</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>
 )
 
@@ -205,9 +205,9 @@ When FALSE, the values will return with no modification. When TRUE (default)
 all values will be round to the length specified by 'n_decimal'.</p></td>
     </tr>
     <tr>
-      <th>scale</th>
-      <td><p>number indicating the scaling factor. When scale = 1, 1/4 will
-return 0.25, when scale = 100 (default) 1/4 will return 25</p></td>
+      <th>multiplier</th>
+      <td><p>number indicating the scaling factor. When multiplier = 1
+(default), 0.25 will return 0.25. When multiplier = 100, 0.25 will return 25.</p></td>
     </tr>
     <tr>
       <th>return_data</th>
@@ -254,7 +254,8 @@ phrase components used to compose the headline</p></td>
   <span class='kw'>headline</span> <span class='kw'>=</span> <span class='st'>"there {were} {delta} {people}"</span>
 )</div><div class='output co'>#&gt; there were 2 people</div><div class='input'>
 <span class='co'># you can also adjust the rounding, although the default is 1</span>
-<span class='fu'>headline</span>(<span class='fl'>0.1234</span>, <span class='fl'>0.4321</span>)</div><div class='output co'>#&gt; decrease of 0.3 (0.1 vs. 0.4)</div><div class='input'><span class='fu'>headline</span>(<span class='fl'>0.1234</span>, <span class='fl'>0.4321</span>, <span class='kw'>n_decimal</span> <span class='kw'>=</span> <span class='fl'>3</span>)</div><div class='output co'>#&gt; decrease of 0.309 (0.123 vs. 0.432)</div><div class='input'>
+<span class='fu'>headline</span>(<span class='fl'>0.1234</span>, <span class='fl'>0.4321</span>)</div><div class='output co'>#&gt; decrease of 0.3 (0.1 vs. 0.4)</div><div class='input'><span class='fu'>headline</span>(<span class='fl'>0.1234</span>, <span class='fl'>0.4321</span>, <span class='kw'>n_decimal</span> <span class='kw'>=</span> <span class='fl'>3</span>)</div><div class='output co'>#&gt; decrease of 0.309 (0.123 vs. 0.432)</div><div class='input'><span class='co'># or use a multiplier</span>
+<span class='fu'>headline</span>(<span class='fl'>0.1234</span>, <span class='fl'>0.4321</span>, <span class='kw'>multiplier</span> <span class='kw'>=</span> <span class='fl'>100</span>)</div><div class='output co'>#&gt; decrease of 30.9 (12.3 vs. 43.2)</div><div class='input'>
 <span class='co'># The values can come from a summarized data frame or a named list</span>
 <span class='co'># if the data frame is only 2 columns or the list has only 2 elements</span>
 <span class='co'># you don't need to specify the 'compare' or 'reference' arguments unless</span>

--- a/man/compare_values.Rd
+++ b/man/compare_values.Rd
@@ -12,7 +12,7 @@ compare_values(
   plural_phrases = NULL,
   n_decimal = 1,
   round_all = TRUE,
-  scale = 100
+  multiplier = 1
 )
 }
 \arguments{
@@ -36,8 +36,8 @@ the returned values.}
 When FALSE, the values will return with no modification. When TRUE (default)
 all values will be round to the length specified by 'n_decimal'.}
 
-\item{scale}{number indicating the scaling factor. When scale = 1, 1/4 will
-return 0.25, when scale = 100 (default) 1/4 will return 25}
+\item{multiplier}{number indicating the scaling factor. When multiplier = 1
+(default), 0.25 will return 0.25. When multiplier = 100, 0.25 will return 25.}
 }
 \description{
 Compare two values and get talking points
@@ -58,6 +58,8 @@ compare_values(10, 8, orig_values = "{c} to {r} people")$orig_values
 # you can also adjust the rounding, although the default is 1
 compare_values(0.1234, 0.4321)$orig_values
 compare_values(0.1234, 0.4321, n_decimal = 3)$orig_values
+# or add a multiplier
+compare_values(0.1234, 0.4321, multiplier = 100)$orig_values
 }
 \seealso{
 \code{\link[=view_list]{view_list()}}, \code{\link[=trend_terms]{trend_terms()}}, and \code{\link[=plural_phrasing]{plural_phrasing()}}

--- a/man/headline.Rd
+++ b/man/headline.Rd
@@ -20,7 +20,7 @@ headline(...)
   orig_values = "{c} vs. {r}",
   n_decimal = 1,
   round_all = TRUE,
-  scale = 100,
+  multiplier = 1,
   return_data = FALSE
 )
 
@@ -62,8 +62,8 @@ the returned values.}
 When FALSE, the values will return with no modification. When TRUE (default)
 all values will be round to the length specified by 'n_decimal'.}
 
-\item{scale}{number indicating the scaling factor. When scale = 1, 1/4 will
-return 0.25, when scale = 100 (default) 1/4 will return 25}
+\item{multiplier}{number indicating the scaling factor. When multiplier = 1
+(default), 0.25 will return 0.25. When multiplier = 100, 0.25 will return 25.}
 
 \item{return_data}{logical to indicate whether function should return the
 phrase components used to compose the headline}
@@ -112,6 +112,8 @@ headline(
 # you can also adjust the rounding, although the default is 1
 headline(0.1234, 0.4321)
 headline(0.1234, 0.4321, n_decimal = 3)
+# or use a multiplier
+headline(0.1234, 0.4321, multiplier = 100)
 
 # The values can come from a summarized data frame or a named list
 # if the data frame is only 2 columns or the list has only 2 elements

--- a/tests/testthat/test-check-rounding.R
+++ b/tests/testthat/test-check-rounding.R
@@ -1,0 +1,5 @@
+test_that("check rounding throws warnings", {
+  expect_warning(check_rounding(0.2, 0.24, n_decimal = 1))
+  expect_null(check_rounding(0.2, 0.24, n_decimal = 2))
+  expect_null(check_rounding(21, 21, n_decimal = 1))
+})

--- a/tests/testthat/test-compare-values.R
+++ b/tests/testthat/test-compare-values.R
@@ -1,3 +1,13 @@
+library(purrr)
+
+keep_numeric <- function(x) {
+  x %>%
+    map(keep, is.numeric) %>%
+    compact() %>%
+    as.numeric()
+}
+
+
 test_that("compare_values produces list", {
   x <- compare_values(2, 3)
 
@@ -17,3 +27,12 @@ test_that("compare_values produces list", {
   )
 })
 
+
+test_that("rescale works", {
+  whole_numbers <- keep_numeric(compare_values(20, 25))
+  rescaled <- keep_numeric(compare_values(0.2, 0.25, rescale = 100))
+  decimal <- keep_numeric(compare_values(0.2, 0.25, n_decimal = 2))
+
+  expect_equal(whole_numbers[1:2], rescaled[1:2])
+  expect_equal(rescaled[1] / 100, decimal[1])
+})

--- a/tests/testthat/test-compare-values.R
+++ b/tests/testthat/test-compare-values.R
@@ -28,11 +28,18 @@ test_that("compare_values produces list", {
 })
 
 
-test_that("rescale works", {
-  whole_numbers <- keep_numeric(compare_values(20, 25))
-  rescaled <- keep_numeric(compare_values(0.2, 0.25, rescale = 100))
-  decimal <- keep_numeric(compare_values(0.2, 0.25, n_decimal = 2))
+test_that("multiplier works", {
+  whole_numbers <- keep_numeric(compare_values(20, 30))
+  multiplierd <- keep_numeric(compare_values(0.2, 0.3, multiplier = 100))
+  decimal <- keep_numeric(compare_values(0.2, 0.3, n_decimal = 2))
 
-  expect_equal(whole_numbers[1:2], rescaled[1:2])
-  expect_equal(rescaled[1] / 100, decimal[1])
+  expect_equal(whole_numbers[1:2], multiplierd[1:2])
+  expect_equal(multiplierd[1] / 100, decimal[1])
+})
+
+test_that("check rounding runs", {
+  expect_warning(compare_values(0.123, 0.12))
+  expect_warning(compare_values(21.1, 21.1))
+  # no wawning
+  expect_warning(compare_values(0.123, 0.1234, n_decimal = 4), regexp = NA)
 })


### PR DESCRIPTION
Fixes #28 
```r
headline(0.4, 0.7)
#> decrease of 0.3 (0.4 vs. 0.7)

headline(0.4, 0.7, multiplier = 100)
#> decrease of 30 (40 vs. 70)
```