### PR TITLE
Adjust how trend_terms is used

### DIFF
--- a/R/compare-values.R
+++ b/R/compare-values.R
@@ -2,7 +2,7 @@
 #'
 #' @param compare a numeric value to compare to a reference value
 #' @param reference a numeric value to act as a control for the 'compare' value
-#' @param trend_phrasing list of values to use for when y is more than x, y is the
+#' @param trend_phrases list of values to use for when y is more than x, y is the
 #' same as x, or y is less than x.
 #' @param plural_phrases named list of values to use when difference (delta) is
 #' singular (delta = 1) or plural (delta != 1)
@@ -27,7 +27,7 @@
 #' compare_values(10, 8) %>% head(2)
 #' # percent difference (10-8)/8
 #' compare_values(10, 8)$delta_p
-#' compare_values(10, 8, trend_phrasing = trend_terms(more = "higher")) %>%
+#' compare_values(10, 8, trend_phrases = trend_terms(more = "higher")) %>%
 #'   head(2)
 #'
 #' # a phrase about the comparion can be edited by providing glue syntax
@@ -40,7 +40,7 @@
 #' # or add a multiplier
 #' compare_values(0.1234, 0.4321, multiplier = 100)$orig_values
 compare_values <- function(compare, reference,
-                           trend_phrasing = headliner::trend_terms(),
+                           trend_phrases = headliner::trend_terms(),
                            orig_values = "{c} vs. {r}",
                            plural_phrases = NULL,
                            n_decimal = 1,
@@ -79,22 +79,25 @@ compare_values <- function(compare, reference,
   }
 
 
-  phrase <-
+  which_trend <-
     recode(
       as.character(calc$sign), # must be a character
-      "1" = trend_phrasing$more,
-      "-1" = trend_phrasing$less,
-      "0" = trend_phrasing$same
+      "1" = "more",
+      "-1" = "less",
+      "0" = "same"
     )
+
+  trend <- trend_phrases[[which_trend]]
+
 
   output <-
     list(
       delta = calc$abs_delta,
-      trend = phrase,
+      trend = trend,
       delta_p = calc$abs_delta_p,
       article_delta = paste(get_article(calc$abs_delta), calc$abs_delta),
       article_delta_p = paste(get_article(calc$abs_delta_p), calc$abs_delta_p),
-      article_trend = paste(get_article(phrase), phrase),
+      article_trend = paste(get_article(trend), trend),
       comp_value = calc$compare,
       ref_value = calc$reference,
       raw_delta = calc$delta,

--- a/R/headline.R
+++ b/R/headline.R
@@ -11,7 +11,7 @@ headline <- function(...) {
 #' @param ... arguments passed to \code{\link[glue]{glue_data}}
 #' @param if_match string to display if numbers match, uses
 #' \code{\link[glue]{glue}} syntax
-#' @param trend_phrasing list of values to use for when y is more than x, y is the
+#' @param trend_phrases list of values to use for when y is more than x, y is the
 #' same as x, or y is less than x.
 #' @param plural_phrases named list of values to use when difference (delta) is
 #' singular (delta = 1) or plural (delta != 1)
@@ -50,7 +50,7 @@ headline <- function(...) {
 #'   compare = 10,
 #'   reference = 8,
 #'   headline = "Group A was {trend} by {delta_p}%.",
-#'   trend_phrasing = trend_terms(more = "higher", less = "lower")
+#'   trend_phrases = trend_terms(more = "higher", less = "lower")
 #'  )
 #'
 #' # a phrase about the comparion can be edited by providing glue syntax
@@ -109,14 +109,14 @@ headline <- function(...) {
 #'      headline =
 #'        "4-cylinder cars get an average of {delta} {trend} miles \\
 #'        per gallon than 6-cylinder cars ({orig_values}).",
-#'      trend_phrasing = trend_terms("more", "less")
+#'      trend_phrases = trend_terms("more", "less")
 #'    )
 headline.default <- function(compare,
                              reference,
                              headline = "{trend} of {delta} ({orig_values})",
                              ...,
                              if_match = "There was no difference.",
-                             trend_phrasing = headliner::trend_terms(),
+                             trend_phrases = headliner::trend_terms(),
                              plural_phrases = NULL,
                              orig_values = "{c} vs. {r}",
                              n_decimal = 1,
@@ -127,7 +127,7 @@ headline.default <- function(compare,
     compare_values(
       compare,
       reference,
-      trend_phrasing = trend_phrasing,
+      trend_phrases = trend_phrases,
       plural_phrases = plural_phrases,
       orig_values = orig_values,
       n_decimal = n_decimal,

--- a/README.Rmd
+++ b/README.Rmd
@@ -159,7 +159,7 @@ headline(
   compare = 1, 
   reference = 2,
   headline = "There {are} {delta} {trend} {people}",
-  trend_phrasing = more_less,
+  trend_phrases = more_less,
   plural_phrases = are_people
 )
 
@@ -167,7 +167,7 @@ headline(
   compare = 3, 
   reference = 1,
   headline = "There {are} {delta} {trend} {people}",
-  trend_phrasing = more_less,
+  trend_phrases = more_less,
   plural_phrases = are_people
 )
 ```
@@ -269,6 +269,6 @@ demo_data() %>%
   ) %>% 
   headline(
     headline = "Group A ({comp_value}) is {delta} points {trend} Group C ({ref_value})",
-    trend_phrasing = trend_terms(more = "ahead",  less = "behind")
+    trend_phrases = trend_terms(more = "ahead",  less = "behind")
   )
 ```

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ headline(
   compare = 1, 
   reference = 2,
   headline = "There {are} {delta} {trend} {people}",
-  trend_phrasing = more_less,
+  trend_phrases = more_less,
   plural_phrases = are_people
 )
 #> There is 1 less person
@@ -228,7 +228,7 @@ headline(
   compare = 3, 
   reference = 1,
   headline = "There {are} {delta} {trend} {people}",
-  trend_phrasing = more_less,
+  trend_phrases = more_less,
   plural_phrases = are_people
 )
 #> There are 2 more people
@@ -339,7 +339,7 @@ demo_data() %>%
   ) %>% 
   headline(
     headline = "Group A ({comp_value}) is {delta} points {trend} Group C ({ref_value})",
-    trend_phrasing = trend_terms(more = "ahead",  less = "behind")
+    trend_phrases = trend_terms(more = "ahead",  less = "behind")
   )
 #> Group A (101.5) is 4 points behind Group C (105.5)
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -222,7 +222,7 @@
   compare <span class="op">=</span> <span class="fl">1</span>, 
   reference <span class="op">=</span> <span class="fl">2</span>,
   headline <span class="op">=</span> <span class="st">"There {are} {delta} {trend} {people}"</span>,
-  trend_phrasing <span class="op">=</span> <span class="va">more_less</span>,
+  trend_phrases <span class="op">=</span> <span class="va">more_less</span>,
   plural_phrases <span class="op">=</span> <span class="va">are_people</span>
 <span class="op">)</span>
 <span class="co">#&gt; There is 1 less person</span>
@@ -231,7 +231,7 @@
   compare <span class="op">=</span> <span class="fl">3</span>, 
   reference <span class="op">=</span> <span class="fl">1</span>,
   headline <span class="op">=</span> <span class="st">"There {are} {delta} {trend} {people}"</span>,
-  trend_phrasing <span class="op">=</span> <span class="va">more_less</span>,
+  trend_phrases <span class="op">=</span> <span class="va">more_less</span>,
   plural_phrases <span class="op">=</span> <span class="va">are_people</span>
 <span class="op">)</span>
 <span class="co">#&gt; There are 2 more people</span></code></pre></div>
@@ -323,7 +323,7 @@
   <span class="op">)</span> <span class="op">%&gt;%</span> 
   <span class="fu"><a href="reference/headline.html">headline</a></span><span class="op">(</span>
     headline <span class="op">=</span> <span class="st">"Group A ({comp_value}) is {delta} points {trend} Group C ({ref_value})"</span>,
-    trend_phrasing <span class="op">=</span> <span class="fu"><a href="reference/trend_terms.html">trend_terms</a></span><span class="op">(</span>more <span class="op">=</span> <span class="st">"ahead"</span>,  less <span class="op">=</span> <span class="st">"behind"</span><span class="op">)</span>
+    trend_phrases <span class="op">=</span> <span class="fu"><a href="reference/trend_terms.html">trend_terms</a></span><span class="op">(</span>more <span class="op">=</span> <span class="st">"ahead"</span>,  less <span class="op">=</span> <span class="st">"behind"</span><span class="op">)</span>
   <span class="op">)</span>
 <span class="co">#&gt; Group A (101.5) is 4 points behind Group C (105.5)</span></code></pre></div>
 </div>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -2,5 +2,5 @@ pandoc: 2.7.3
 pkgdown: 1.6.1
 pkgdown_sha: ~
 articles: {}
-last_built: 2021-02-07T17:56Z
+last_built: 2021-02-07T22:14Z
 

--- a/docs/reference/compare_values.html
+++ b/docs/reference/compare_values.html
@@ -128,7 +128,7 @@
     <pre class="usage"><span class='fu'>compare_values</span><span class='op'>(</span>
   <span class='va'>compare</span>,
   <span class='va'>reference</span>,
-  trend_phrasing <span class='op'>=</span> <span class='fu'>headliner</span><span class='fu'>::</span><span class='fu'><a href='trend_terms.html'>trend_terms</a></span><span class='op'>(</span><span class='op'>)</span>,
+  trend_phrases <span class='op'>=</span> <span class='fu'>headliner</span><span class='fu'>::</span><span class='fu'><a href='trend_terms.html'>trend_terms</a></span><span class='op'>(</span><span class='op'>)</span>,
   orig_values <span class='op'>=</span> <span class='st'>"{c} vs. {r}"</span>,
   plural_phrases <span class='op'>=</span> <span class='cn'>NULL</span>,
   n_decimal <span class='op'>=</span> <span class='fl'>1</span>,
@@ -148,7 +148,7 @@
       <td><p>a numeric value to act as a control for the 'compare' value</p></td>
     </tr>
     <tr>
-      <th>trend_phrasing</th>
+      <th>trend_phrases</th>
       <td><p>list of values to use for when y is more than x, y is the
 same as x, or y is less than x.</p></td>
     </tr>
@@ -195,7 +195,7 @@ all values will be round to the length specified by 'n_decimal'.</p></td>
 #&gt; [1] "increase"
 #&gt; </div><div class='input'><span class='co'># percent difference (10-8)/8</span>
 <span class='fu'>compare_values</span><span class='op'>(</span><span class='fl'>10</span>, <span class='fl'>8</span><span class='op'>)</span><span class='op'>$</span><span class='va'>delta_p</span>
-</div><div class='output co'>#&gt; [1] 25</div><div class='input'><span class='fu'>compare_values</span><span class='op'>(</span><span class='fl'>10</span>, <span class='fl'>8</span>, trend_phrasing <span class='op'>=</span> <span class='fu'><a href='trend_terms.html'>trend_terms</a></span><span class='op'>(</span>more <span class='op'>=</span> <span class='st'>"higher"</span><span class='op'>)</span><span class='op'>)</span> <span class='op'>%&gt;%</span>
+</div><div class='output co'>#&gt; [1] 25</div><div class='input'><span class='fu'>compare_values</span><span class='op'>(</span><span class='fl'>10</span>, <span class='fl'>8</span>, trend_phrases <span class='op'>=</span> <span class='fu'><a href='trend_terms.html'>trend_terms</a></span><span class='op'>(</span>more <span class='op'>=</span> <span class='st'>"higher"</span><span class='op'>)</span><span class='op'>)</span> <span class='op'>%&gt;%</span>
   <span class='fu'><a href='https://rdrr.io/r/utils/head.html'>head</a></span><span class='op'>(</span><span class='fl'>2</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; $delta
 #&gt; [1] 2

--- a/docs/reference/headline.html
+++ b/docs/reference/headline.html
@@ -134,7 +134,7 @@
   headline <span class='op'>=</span> <span class='st'>"{trend} of {delta} ({orig_values})"</span>,
   <span class='va'>...</span>,
   if_match <span class='op'>=</span> <span class='st'>"There was no difference."</span>,
-  trend_phrasing <span class='op'>=</span> <span class='fu'>headliner</span><span class='fu'>::</span><span class='fu'><a href='trend_terms.html'>trend_terms</a></span><span class='op'>(</span><span class='op'>)</span>,
+  trend_phrases <span class='op'>=</span> <span class='fu'>headliner</span><span class='fu'>::</span><span class='fu'><a href='trend_terms.html'>trend_terms</a></span><span class='op'>(</span><span class='op'>)</span>,
   plural_phrases <span class='op'>=</span> <span class='cn'>NULL</span>,
   orig_values <span class='op'>=</span> <span class='st'>"{c} vs. {r}"</span>,
   n_decimal <span class='op'>=</span> <span class='fl'>1</span>,
@@ -178,7 +178,7 @@
 <code><a href='https://glue.tidyverse.org/reference/glue.html'>glue</a></code> syntax</p></td>
     </tr>
     <tr>
-      <th>trend_phrasing</th>
+      <th>trend_phrases</th>
       <td><p>list of values to use for when y is more than x, y is the
 same as x, or y is less than x.</p></td>
     </tr>
@@ -242,7 +242,7 @@ phrase components used to compose the headline</p></td>
   compare <span class='op'>=</span> <span class='fl'>10</span>,
   reference <span class='op'>=</span> <span class='fl'>8</span>,
   headline <span class='op'>=</span> <span class='st'>"Group A was {trend} by {delta_p}%."</span>,
-  trend_phrasing <span class='op'>=</span> <span class='fu'><a href='trend_terms.html'>trend_terms</a></span><span class='op'>(</span>more <span class='op'>=</span> <span class='st'>"higher"</span>, less <span class='op'>=</span> <span class='st'>"lower"</span><span class='op'>)</span>
+  trend_phrases <span class='op'>=</span> <span class='fu'><a href='trend_terms.html'>trend_terms</a></span><span class='op'>(</span>more <span class='op'>=</span> <span class='st'>"higher"</span>, less <span class='op'>=</span> <span class='st'>"lower"</span><span class='op'>)</span>
  <span class='op'>)</span>
 </div><div class='output co'>#&gt; Group A was higher by 25%.</div><div class='input'>
 <span class='co'># a phrase about the comparion can be edited by providing glue syntax</span>
@@ -286,10 +286,10 @@ phrase components used to compose the headline</p></td>
 <span class='fu'>headline</span><span class='op'>(</span>
   compare <span class='op'>=</span> <span class='fl'>16</span>,
   reference <span class='op'>=</span> <span class='fl'>8</span>,
-  headline <span class='op'>=</span> <span class='st'>"there was {article_delta_p} {delta_p}% {trend}, \\
+  headline <span class='op'>=</span> <span class='st'>"there was {article_delta_p}% {trend}, \\
   {article_trend} {trend} of {delta} ({orig_values})"</span>
 <span class='op'>)</span>
-</div><div class='output co'>#&gt; there was a 100 100% increase, an increase increase of 8 (16 vs. 8)</div><div class='input'>
+</div><div class='output co'>#&gt; there was a 100% increase, an increase increase of 8 (16 vs. 8)</div><div class='input'>
 <span class='co'># compare_conditions() produces a list that can be passed to headline()</span>
  <span class='va'>mtcars</span> <span class='op'>%&gt;%</span>
    <span class='fu'><a href='compare_conditions.html'>compare_conditions</a></span><span class='op'>(</span>
@@ -301,7 +301,7 @@ phrase components used to compose the headline</p></td>
      headline <span class='op'>=</span>
        <span class='st'>"4-cylinder cars get an average of {delta} {trend} miles \\
        per gallon than 6-cylinder cars ({orig_values})."</span>,
-     trend_phrasing <span class='op'>=</span> <span class='fu'><a href='trend_terms.html'>trend_terms</a></span><span class='op'>(</span><span class='st'>"more"</span>, <span class='st'>"less"</span><span class='op'>)</span>
+     trend_phrases <span class='op'>=</span> <span class='fu'><a href='trend_terms.html'>trend_terms</a></span><span class='op'>(</span><span class='st'>"more"</span>, <span class='st'>"less"</span><span class='op'>)</span>
    <span class='op'>)</span>
 </div><div class='output co'>#&gt; 4-cylinder cars get an average of 6.9 more miles per gallon than 6-cylinder cars (26.7 vs. 19.7).</div></pre>
   </div>

--- a/man/compare_values.Rd
+++ b/man/compare_values.Rd
@@ -7,7 +7,7 @@
 compare_values(
   compare,
   reference,
-  trend_phrasing = headliner::trend_terms(),
+  trend_phrases = headliner::trend_terms(),
   orig_values = "{c} vs. {r}",
   plural_phrases = NULL,
   n_decimal = 1,
@@ -20,7 +20,7 @@ compare_values(
 
 \item{reference}{a numeric value to act as a control for the 'compare' value}
 
-\item{trend_phrasing}{list of values to use for when y is more than x, y is the
+\item{trend_phrases}{list of values to use for when y is more than x, y is the
 same as x, or y is less than x.}
 
 \item{orig_values}{a string using \code{\link[glue]{glue}} syntax. \code{{c}} =
@@ -48,7 +48,7 @@ Compare two values and get talking points
 compare_values(10, 8) \%>\% head(2)
 # percent difference (10-8)/8
 compare_values(10, 8)$delta_p
-compare_values(10, 8, trend_phrasing = trend_terms(more = "higher")) \%>\%
+compare_values(10, 8, trend_phrases = trend_terms(more = "higher")) \%>\%
   head(2)
 
 # a phrase about the comparion can be edited by providing glue syntax

--- a/man/headline.Rd
+++ b/man/headline.Rd
@@ -15,7 +15,7 @@ headline(...)
   headline = "{trend} of {delta} ({orig_values})",
   ...,
   if_match = "There was no difference.",
-  trend_phrasing = headliner::trend_terms(),
+  trend_phrases = headliner::trend_terms(),
   plural_phrases = NULL,
   orig_values = "{c} vs. {r}",
   n_decimal = 1,
@@ -45,7 +45,7 @@ headline(...)
 \item{if_match}{string to display if numbers match, uses
 \code{\link[glue]{glue}} syntax}
 
-\item{trend_phrasing}{list of values to use for when y is more than x, y is the
+\item{trend_phrases}{list of values to use for when y is more than x, y is the
 same as x, or y is less than x.}
 
 \item{plural_phrases}{named list of values to use when difference (delta) is
@@ -91,7 +91,7 @@ headline(
   compare = 10,
   reference = 8,
   headline = "Group A was {trend} by {delta_p}\%.",
-  trend_phrasing = trend_terms(more = "higher", less = "lower")
+  trend_phrases = trend_terms(more = "higher", less = "lower")
  )
 
 # a phrase about the comparion can be edited by providing glue syntax
@@ -135,7 +135,7 @@ iris \%>\%
 headline(
   compare = 16,
   reference = 8,
-  headline = "there was {article_delta_p} {delta_p}\% {trend}, \\\\
+  headline = "there was {article_delta_p}\% {trend}, \\\\
   {article_trend} {trend} of {delta} ({orig_values})"
 )
 
@@ -150,7 +150,7 @@ headline(
      headline =
        "4-cylinder cars get an average of {delta} {trend} miles \\\\
        per gallon than 6-cylinder cars ({orig_values}).",
-     trend_phrasing = trend_terms("more", "less")
+     trend_phrases = trend_terms("more", "less")
    )
 }
 \seealso{

--- a/tests/testthat/test-compare-values.R
+++ b/tests/testthat/test-compare-values.R
@@ -54,3 +54,17 @@ test_that("check rounding runs", {
   expect_warning(compare_values(0.123, 0.1234, n_decimal = 4), regexp = NA)
   expect_warning(compare_values(0.12, 0.123, multiplier = 100), regexp = NA)
 })
+
+
+test_that("compare_values accepts multiple trend terms", {
+  use_values <- c("increase", "higher")
+
+  x <-
+    compare_values(
+      5, 4,
+      trend_phrases = trend_terms(more = use_values)
+    )
+
+  expect_equal(x$trend, use_values)
+  expect_equal(x$article_trend, paste(c("an", "a"), use_values))
+})


### PR DESCRIPTION
Fixes #40 - align param naming convention 
Fixes #46 - pass multiple trend terms