### PR TITLE
Only `filter()` if `cond` is provided

### DIFF
--- a/R/utils-data-manipulation.R
+++ b/R/utils-data-manipulation.R
@@ -41,8 +41,13 @@ aggregate_group <- function(df, name, .cols, .fns, cond) {
   # df <- mtcars; name = "_x";  .cols <- as.symbol("mpg"); .fns = mean
   # cond <- dplyr::quo(cyl > 4);
 
+  cond <- rlang::enquo(cond)
+
+  if (!rlang::quo_is_missing(cond)) {
+    df <- filter(df, {{cond}})
+  }
+
   df |>
-    filter({{cond}}) |>
     summarise(
       across({{.cols}}, .fns, .names = "{.fn}_{.col}{name}")
     )


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

The way we capture `...` in `filter()` has slightly changed. This currently has the side effect that you can't inject "missing" quosures into `filter()`, which is something you happened to be doing. We are going to think about this further in https://github.com/r-lib/rlang/issues/1421, but in the meantime it would be great if you could merge this to work around that issue altogether.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!